### PR TITLE
4-pp-context-on stream-should-be-removed

### DIFF
--- a/src/BaselineOfPetitParser/BaselineOfPetitParser.class.st
+++ b/src/BaselineOfPetitParser/BaselineOfPetitParser.class.st
@@ -15,6 +15,7 @@ BaselineOfPetitParser >> baseline: spec [
 			
 			spec
 				package: 'PetitParser';
+				package: 'PetitParser-Deprecated' with: [ spec requires: 'PetitParser' ];
 				package: 'PetitTests' with: [ spec requires: 'PetitParser' ];
 				package: 'PetitParser-Tests' with: [ spec requires: #('Core') ];
 				package: 'PetitParser-Examples' with: [ spec requires: 'PetitParser' ];
@@ -33,7 +34,7 @@ BaselineOfPetitParser >> baseline: spec [
 			self defineGrammarsOn: spec.
 			
 			spec
-				group: 'Core' with: #('PetitParser' 'PetitTests');
+				group: 'Core' with: #('PetitParser' 'PetitTests' 'PetitParser-Deprecated');
 				group: 'Tests' with: #('Core' 'PetitParser-Tests' );
 				group: 'Examples' with: #('Core' 'PetitParser-Examples');
 				group: 'Islands' with: #('PetitIslands' 'PetitIslands-Examples' 'PetitIslands-Tests');

--- a/src/PetitParser-Deprecated/PPContext.extension.st
+++ b/src/PetitParser-Deprecated/PPContext.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #PPContext }
+
+{ #category : #'*PetitParser-Deprecated' }
+PPContext class >> on: aPPParser stream: aStream [
+	self deprecated: 'This method is not working. It should not be referenced from your project nor be called.'.
+	^ self basicNew 
+		initialize;
+		root: aPPParser;
+		stream: aStream asPetitStream;
+		yourself
+]

--- a/src/PetitParser-Deprecated/package.st
+++ b/src/PetitParser-Deprecated/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'PetitParser-Deprecated' }

--- a/src/PetitParser/PPContext.class.st
+++ b/src/PetitParser/PPContext.class.st
@@ -33,15 +33,6 @@ Class {
 	#category : #'PetitParser-Core'
 }
 
-{ #category : #'as yet unclassified' }
-PPContext class >> on: aPPParser stream: aStream [
-	^ self basicNew 
-		initialize;
-		root: aPPParser;
-		stream: aStream asPetitStream;
-		yourself
-]
-
 { #category : #'stream mimicry' }
 PPContext >> atEnd [
 	^ stream atEnd


### PR DESCRIPTION
Deprecated the method and put it in a separated package to be easily removed when next major release is created.

Fixes issue #4.