### PR TITLE
3 use notation for examples inside methods

### DIFF
--- a/src/PetitParser/Collection.extension.st
+++ b/src/PetitParser/Collection.extension.st
@@ -7,7 +7,14 @@ Collection >> asChoiceParser [
 
 { #category : #'*PetitParser' }
 Collection >> asParser [    
-	"Create a range of characters between start and stop."
+	"Create a range of characters between start and stop.
+	
+	This example works and parse the input:
+		(#($a $b $c $d $e $f) asParser parse: 'a') >>> $a
+	
+	This example results in a PPFailure:
+		(#($a $b $c $d $e $f) asParser parse: 'g') asString >>> 'One of these charactes expected: #($a $b $c $d $e $f) at 0'
+	"
 
 	(self allSatisfy: [ :e | e isCharacter ]) ifTrue: [ 
 		| charSet |
@@ -17,10 +24,6 @@ Collection >> asParser [
 
 
 	^ super asParser
-	"
-		($a to:$f) asParser parse:'a'
-		($a to:$f) asParser parse:'g'
-	"
 
 ]
 

--- a/src/PetitParser/Interval.extension.st
+++ b/src/PetitParser/Interval.extension.st
@@ -2,15 +2,17 @@ Extension { #name : #Interval }
 
 { #category : #'*PetitParser' }
 Interval >> asParser [    
-	"Create a range of characters between start and stop."
+	"Create a range of characters between start and stop.
+	
+	This example works and parse the input:
+		(($a to: $f) asParser parse: 'a') >>> $a
+	
+	This example results in a PPFailure:
+		(($a to: $f) asParser parse: 'g') asString >>> 'One of these charactes expected: #($a $b $c $d $e $f) at 0'
+	"
 
     self assert:start isCharacter.
     self assert:stop isCharacter.
     self assert:step == 1.
     ^ PPPredicateObjectParser between: start and: stop
-
-    "
-		($a to: $f) asParser parse: 'a'
-		($a to: $f) asParser parse: 'g'
-    "
 ]

--- a/src/PetitParser/PPLimitedChoiceParser.class.st
+++ b/src/PetitParser/PPLimitedChoiceParser.class.st
@@ -52,7 +52,6 @@ PPLimitedChoiceParser >> parseOn: aPPContext [
 	"This is optimized code that avoids unnecessary block activations, do not change. When all choices fail, the last failure is answered."
 
 	| element limitResult memento |
-	"self halt."
 	1 to: parsers size do: [ :index |
 		memento := aPPContext remember.
 		


### PR DESCRIPTION
This fixes issue #3.

Only PetitParser package was reviewed. I do not think other packages have such comments.