### PR TITLE
 Periods and semicolon are contained in array items in pharo (in UnifiededFFI for example)  They are parsed from RBParser into a RBLiteralValueNode.

### DIFF
--- a/src/PetitSmalltalk/PPSmalltalkGrammar.class.st
+++ b/src/PetitSmalltalk/PPSmalltalkGrammar.class.st
@@ -117,17 +117,17 @@ PPSmalltalkGrammar >> array [
 	^ ${ asParser smalltalkToken , (expression delimitedBy: periodToken) optional , $} asParser smalltalkToken
 ]
 
-{ #category : #'grammar-literals' }
+{ #category : #grammar }
 PPSmalltalkGrammar >> arrayItem [
 	^ arrayItemPeriod / arrayItemSemicolon / literal / symbolLiteralArray / arrayLiteralArray / byteLiteralArray
 ]
 
-{ #category : #'as yet unclassified' }
-PPSmalltalkGrammar >> arrayItemPeriod [
+{ #category : #grammar }
+PPSmalltalkGrammar >> arrayItemPeriod [ 
    ^ ($. asParser) token
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #grammar }
 PPSmalltalkGrammar >> arrayItemSemicolon [
    ^ ($; asParser) token
 ]

--- a/src/PetitSmalltalk/PPSmalltalkGrammar.class.st
+++ b/src/PetitSmalltalk/PPSmalltalkGrammar.class.st
@@ -79,14 +79,17 @@ Class {
 		'unaryMethod',
 		'unaryPragma',
 		'unaryToken',
-		'variable'
+		'variable',
+		'arrayItemPeriod',
+		'arrayItemSemicolon'
 	],
 	#category : #PetitSmalltalk
 }
 
 { #category : #testing }
 PPSmalltalkGrammar class >> allowUnderscoreAssignment [
-	^ (Scanner respondsTo: #allowUnderscoreAsAssignment) and: [ Scanner allowUnderscoreAsAssignment ]
+	"^ (Scanner respondsTo: #allowUnderscoreAsAssignment) and: [ Scanner allowUnderscoreAsAssignment ]"
+	^false
 ]
 
 { #category : #accessing }
@@ -116,7 +119,17 @@ PPSmalltalkGrammar >> array [
 
 { #category : #'grammar-literals' }
 PPSmalltalkGrammar >> arrayItem [
-	^ literal / symbolLiteralArray / arrayLiteralArray / byteLiteralArray
+	^ arrayItemPeriod / arrayItemSemicolon / literal / symbolLiteralArray / arrayLiteralArray / byteLiteralArray
+]
+
+{ #category : #'as yet unclassified' }
+PPSmalltalkGrammar >> arrayItemPeriod [
+   ^ ($. asParser) token
+]
+
+{ #category : #'as yet unclassified' }
+PPSmalltalkGrammar >> arrayItemSemicolon [
+   ^ ($; asParser) token
 ]
 
 { #category : #'grammar-literals' }

--- a/src/PetitSmalltalk/PPSmalltalkParser.class.st
+++ b/src/PetitSmalltalk/PPSmalltalkParser.class.st
@@ -34,6 +34,28 @@ PPSmalltalkParser >> array [
 ]
 
 { #category : #'grammar-literals' }
+PPSmalltalkParser >> arrayItemPeriod [
+	^ super arrayItemPeriod
+	==> [ :token | 
+	        (RBLiteralValueNode
+				value: (self buildString: token inputValue) asSymbol
+				start: token start
+				 stop: token stop)
+	 ]
+]
+
+{ #category : #'as yet unclassified' }
+PPSmalltalkParser >> arrayItemSemicolon [
+   ^ super arrayItemSemicolon
+	==> [ :token | 
+         (RBLiteralValueNode
+				value: (self buildString: token inputValue) asSymbol
+				start: token start
+				 stop: token stop)
+	 ]
+]
+
+{ #category : #'grammar-literals' }
 PPSmalltalkParser >> arrayLiteral [
 	^ super arrayLiteral
 		==> [ :nodes | 

--- a/src/PetitSmalltalk/PPSmalltalkParser.class.st
+++ b/src/PetitSmalltalk/PPSmalltalkParser.class.st
@@ -33,7 +33,7 @@ PPSmalltalkParser >> array [
 			yourself ]
 ]
 
-{ #category : #'grammar-literals' }
+{ #category : #grammar }
 PPSmalltalkParser >> arrayItemPeriod [
 	^ super arrayItemPeriod
 	==> [ :token | 
@@ -44,7 +44,7 @@ PPSmalltalkParser >> arrayItemPeriod [
 	 ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #grammar }
 PPSmalltalkParser >> arrayItemSemicolon [
    ^ super arrayItemSemicolon
 	==> [ :token | 


### PR DESCRIPTION
Hello, this is my first try to contribute.
I did a change in PetitParser in my own branch and wanted that this change is apply in the original source tree. Please have a look.

Thank you