### PR TITLE
47-Preprocessor-does-not-set-root-parser-for-context

### DIFF
--- a/src/PetitPreprocessor/PPreStreamPreProcessor.class.st
+++ b/src/PetitPreprocessor/PPreStreamPreProcessor.class.st
@@ -16,7 +16,10 @@ PPreStreamPreProcessor >> parseOn: aPPContext [
 	startPosition := aPPContext position.
 	preProcessedStream := (self preProcess: aPPContext stream).
 	"call the contained parser"
-	result := super parseOn: (PPContext new stream: preProcessedStream).
+	result := super parseOn: (PPContext new
+										initializeFor: self;
+										stream: preProcessedStream;
+										yourself).
 	result isPetitFailure 
 		ifTrue: 
 			"restore stream position"


### PR DESCRIPTION
Now root parser is set correctly for pre-processors.